### PR TITLE
Update deps to use jito-solana fork from exo-tech-xyz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 name = "agave-banking-stage-ingress-types"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
@@ -75,7 +75,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule 3.0.0",
@@ -88,7 +88,7 @@ dependencies = [
 [[package]]
 name = "agave-geyser-plugin-interface"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "log",
  "solana-clock 3.0.0",
@@ -102,7 +102,7 @@ dependencies = [
 [[package]]
 name = "agave-io-uring"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "io-uring",
  "libc",
@@ -114,12 +114,12 @@ dependencies = [
 [[package]]
 name = "agave-low-pass-filter"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 
 [[package]]
 name = "agave-precompiles"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "agave-reserved-account-keys"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 3.0.0",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "libsecp256k1 0.6.0",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-hash 3.0.0",
  "solana-message 3.0.0",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "agave-verified-packet-receiver"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-perf",
  "solana-streamer",
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "agave-votor"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "agave-xdp"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "aya",
  "caps",
@@ -324,7 +324,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "proc-macro2 1.0.101",
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "proc-macro2 1.0.101",
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-interface"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -456,7 +456,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-state"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-syn 0.24.2",
  "anyhow",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-attribute-access-control 0.24.2",
  "anchor-attribute-account 0.24.2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.24.2"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
@@ -3941,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "jito-programs-vote-state"
 version = "0.1.5"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-lang 0.24.2",
  "bincode",
@@ -3953,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "jito-protos"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bytes",
  "prost 0.11.9",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "jito-tip-distribution"
 version = "0.1.5"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-lang 0.24.2",
  "default-env",
@@ -4061,7 +4061,7 @@ dependencies = [
 [[package]]
 name = "jito-tip-payment"
 version = "0.1.5"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-lang 0.24.2",
  "default-env",
@@ -7390,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -7473,7 +7473,7 @@ dependencies = [
 [[package]]
 name = "solana-accounts-db"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-io-uring",
  "ahash 0.8.12",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "borsh 1.5.7",
  "futures 0.3.31",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-interface"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "solana-banks-server"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "solana-bloom"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bv",
  "fnv",
@@ -7819,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -7847,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "solana-bucket-map"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bv",
  "bytemuck",
@@ -7865,7 +7865,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "solana-builtins-default-costs"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7903,7 +7903,7 @@ dependencies = [
 [[package]]
 name = "solana-bundle"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anchor-lang 0.24.2",
  "itertools 0.12.1",
@@ -7932,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "solana-bundle-sdk"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "digest 0.10.7",
  "itertools 0.12.1",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "dirs-next",
  "serde",
@@ -7986,7 +7986,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-output"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -8027,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-fee-structure 3.0.0",
  "solana-program-runtime",
@@ -8191,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-instruction"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "log",
@@ -8235,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -8260,7 +8260,7 @@ dependencies = [
 [[package]]
 name = "solana-connection-cache"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -8282,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "solana-core"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-feature-set",
@@ -8432,7 +8432,7 @@ dependencies = [
 [[package]]
 name = "solana-cost-model"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -8501,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "solana-curve25519"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "solana-entry"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -8757,7 +8757,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "clap 2.34.0",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "solana-fee"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure 3.0.0",
@@ -8954,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "solana-geyser-plugin-manager"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58 0.5.1",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "solana-gossip"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "agave-low-pass-filter",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "solana-lattice-hash"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "solana-ledger"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -9506,7 +9506,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -9556,12 +9556,12 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 
 [[package]]
 name = "solana-merkle-tree"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "fast-math",
  "solana-hash 3.0.0",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -9659,7 +9659,7 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 [[package]]
 name = "solana-net-utils"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9797,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "solana-poh"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "arc-swap",
  "core_affinity",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "solana-poseidon"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -10169,7 +10169,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10210,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "solana-program-test"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "assert_matches",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "solana-pubsub-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "solana-quic-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "log",
  "num_cpus",
@@ -10392,7 +10392,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "console 0.16.1",
  "dialoguer",
@@ -10500,7 +10500,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "base64 0.22.1",
@@ -10589,7 +10589,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10628,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-nonce-utils"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-account 3.1.0",
  "solana-commitment-config 3.0.0",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client-types"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -10694,7 +10694,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -10829,7 +10829,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-plugin"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "crossbeam-channel",
  "json5",
@@ -10848,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime-transaction"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "solana-send-transaction-service"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -11488,7 +11488,7 @@ dependencies = [
 [[package]]
 name = "solana-stake-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -11516,7 +11516,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-bigtable"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-reserved-account-keys",
  "backoff",
@@ -11557,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "solana-storage-proto"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "bs58 0.5.1",
@@ -11581,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -11673,7 +11673,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-account 3.1.0",
  "solana-clock 3.0.0",
@@ -11684,12 +11684,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "log",
 ]
@@ -11697,12 +11697,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 
 [[package]]
 name = "solana-svm-metrics"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -11717,7 +11717,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-timings"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -11727,7 +11727,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-transaction"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "solana-hash 3.0.0",
  "solana-message 3.0.0",
@@ -11740,7 +11740,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -11779,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "log",
@@ -11938,7 +11938,7 @@ checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 [[package]]
 name = "solana-tls-utils"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "rustls 0.23.32",
  "solana-keypair 3.0.0",
@@ -11950,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -11983,7 +11983,7 @@ dependencies = [
 [[package]]
 name = "solana-tpu-client-next"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "log",
@@ -12074,7 +12074,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "serde",
@@ -12115,7 +12115,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-metrics-tracker"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -12130,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "Inflector",
  "agave-reserved-account-keys",
@@ -12173,7 +12173,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -12197,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "solana-turbine"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "agave-xdp",
@@ -12250,7 +12250,7 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -12265,7 +12265,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "assert_matches",
  "solana-pubkey 3.0.0",
@@ -12278,7 +12278,7 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-pool"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -12325,7 +12325,7 @@ checksum = "c5d2face763df5afeaa9509b9019968860e69cc1531ec8b4a2e6c7b702204d5a"
 [[package]]
 name = "solana-version"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "rand 0.8.5",
@@ -12339,7 +12339,7 @@ dependencies = [
 [[package]]
 name = "solana-vote"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "bincode",
  "itertools 0.12.1",
@@ -12444,7 +12444,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -12476,7 +12476,7 @@ dependencies = [
 [[package]]
 name = "solana-wen-restart"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "anyhow",
  "log",
@@ -12503,7 +12503,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -12556,7 +12556,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-proof-program"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "agave-feature-set",
  "bytemuck",
@@ -12572,7 +12572,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-token-sdk"
 version = "3.0.0"
-source = "git+https://github.com/jito-foundation/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
+source = "git+https://github.com/exo-tech-xyz/jito-solana.git?rev=93c4da92ba1f2db5963a3ba678d6c34b123cca5a#93c4da92ba1f2db5963a3ba678d6c34b123cca5a"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,46 +76,46 @@ serde_json = "1.0.102"
 serde_with = "3.9.0"
 shank = "0.4.2"
 shank_idl = "0.4.2"
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-account-info = { package = "solana-account-info", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-account-info = { package = "solana-account-info", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-address-lookup-table-interface = { version = "=3.0.0" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-clock = { package = "solana-clock", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-client = { package = "solana-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-clock = { package = "solana-clock", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-commitment-config = "=3.0.0"
 solana-compute-budget-interface = { version = "=3.0.0" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-core = { package = "solana-core", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-decode-error = "=2.3.0"
 solana-genesis-config = "=3.0.0"
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-instruction = { package = "solana-instruction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-measure = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-gossip = { package = "solana-gossip", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-instruction = { package = "solana-instruction", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-measure = { git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-program = { version = "3.0.0", default-features = false, features = [] }
 solana-program-entrypoint = "3.0.0"
 solana-program-error = "=3.0.0"
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-pubkey = "=3.0.0"
-solana-rpc = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rpc-client-api = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc = { git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc-client-api = { git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-sdk = "=3.0.0"
 solana-security-txt = "1.1.1"
 solana-stake-interface = { version = "2.0.1", features = ["sysvar"] }
-solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-streamer = { git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-stake-program = { package = "solana-stake-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-streamer = { git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-system-interface = { version = "2.0.0", features = ["bincode"] }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-vote = { package = "solana-vote", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 solana-vote-interface = { version = "=4.0.2", features = ["bincode"] }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-math = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-memo-interface = "2.0.0"
@@ -136,76 +136,76 @@ incremental = false
 codegen-units = 1
 
 [patch.crates-io]
-solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-banks-client = { package = "solana-banks-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-banks-server = { package = "solana-banks-server", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-bloom = { package = "solana-bloom", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-cli-config = { package = "solana-cli-config", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-client = { package = "solana-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-core = { package = "solana-core", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-cost-model = { package = "solana-cost-model", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-entry = { package = "solana-entry", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-faucet = { package = "solana-faucet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-fee = { package = "solana-fee", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-gossip = { package = "solana-gossip", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-ledger = { package = "solana-ledger", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-measure = { package = "solana-measure", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-metrics = { package = "solana-metrics", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-net-utils = { package = "solana-net-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-perf = { package = "solana-perf", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-poh = { package = "solana-poh", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-poseidon = { package = "solana-poseidon", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-program-test = { package = "solana-program-test", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-quic-client = { package = "solana-quic-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-timings = { package = "solana-timings", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rpc = { package = "solana-rpc", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-runtime = { package = "solana-runtime", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-stake-program = { package = "solana-stake-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-streamer = { package = "solana-streamer", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-svm = { package = "solana-svm", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-system-program = { package = "solana-system-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-turbine = { package = "solana-turbine", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-udp-client = { package = "solana-udp-client", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-version = { package = "solana-version", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-vote = { package = "solana-vote", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-vote-program = { package = "solana-vote-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
-#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/jito-foundation/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-account-decoder = { package = "solana-account-decoder", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-account-decoder-client-types = { package = "solana-account-decoder-client-types", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-accounts-db = { package = "solana-accounts-db", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-banks-client = { package = "solana-banks-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-banks-interface = { package = "solana-banks-interface", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-banks-server = { package = "solana-banks-server", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-bloom = { package = "solana-bloom", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-bpf-loader-program = { package = "solana-bpf-loader-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-bucket-map = { package = "solana-bucket-map", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-builtins-default-costs = { package = "solana-builtins-default-costs", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-clap-utils = { package = "solana-clap-utils", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-cli-config = { package = "solana-cli-config", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-client = { package = "solana-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-compute-budget = { package = "solana-compute-budget", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-connection-cache = { package = "solana-connection-cache", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-core = { package = "solana-core", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-cost-model = { package = "solana-cost-model", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-curve25519 = { package = "solana-curve25519", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-entry = { package = "solana-entry", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-faucet = { package = "solana-faucet", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-fee = { package = "solana-fee", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-geyser-plugin-manager = { package = "solana-geyser-plugin-manager", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-gossip = { package = "solana-gossip", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-lattice-hash = { package = "solana-lattice-hash", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-ledger = { package = "solana-ledger", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-loader-v4-program = { package = "solana-loader-v4-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-measure = { package = "solana-measure", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-merkle-tree = { package = "solana-merkle-tree", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-metrics = { package = "solana-metrics", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-net-utils = { package = "solana-net-utils", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-perf = { package = "solana-perf", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-poh = { package = "solana-poh", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-poseidon = { package = "solana-poseidon", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-program-runtime = { package = "solana-program-runtime", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-program-test = { package = "solana-program-test", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-pubsub-client = { package = "solana-pubsub-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-quic-client = { package = "solana-quic-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rayon-threadlimit = { package = "solana-rayon-threadlimit", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-remote-wallet = { package = "solana-remote-wallet", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-timings = { package = "solana-timings", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-unified-scheduler-logic = { package = "solana-unified-scheduler-logic", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-unified-scheduler-pool = { package = "solana-unified-scheduler-pool", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc = { package = "solana-rpc", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc-client = { package = "solana-rpc-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc-client-api = { package = "solana-rpc-client-api", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-rpc-client-nonce-utils = { package = "solana-rpc-client-nonce-utils", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-runtime = { package = "solana-runtime", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-runtime-transaction = { package = "solana-runtime-transaction", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-send-transaction-service = { package = "solana-send-transaction-service", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-stake-program = { package = "solana-stake-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-storage-bigtable = { package = "solana-storage-bigtable", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-storage-proto = { package = "solana-storage-proto", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-streamer = { package = "solana-streamer", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-svm = { package = "solana-svm", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-svm-rent-collector = { package = "solana-svm-rent-collector", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-svm-transaction = { package = "solana-svm-transaction", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-system-program = { package = "solana-system-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-thin-client = { package = "solana-thin-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-tpu-client = { package = "solana-tpu-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-transaction-status = { package = "solana-transaction-status", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-transaction-status-client-types = { package = "solana-transaction-status-client-types", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-transaction-metrics-tracker = { package = "solana-transaction-metrics-tracker", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-turbine = { package = "solana-turbine", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-type-overrides = { package = "solana-type-overrides", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-udp-client = { package = "solana-udp-client", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-version = { package = "solana-version", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-vote = { package = "solana-vote", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-vote-program = { package = "solana-vote-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-wen-restart = { package = "solana-wen-restart", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+solana-zk-elgamal-proof-program = { package = "solana-zk-elgamal-proof-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-zk-sdk = { package = "solana-zk-sdk", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-zk-token-proof-program = { package = "solana-zk-token-proof-program", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }
+#solana-zk-token-sdk = { package = "solana-zk-token-sdk", git = "https://github.com/exo-tech-xyz/jito-solana.git", rev = "93c4da92ba1f2db5963a3ba678d6c34b123cca5a" }


### PR DESCRIPTION
Update deps to use jito-solana fork from `exo-tech-xyz` to avoid build environment disruptions when dependencies are yanked.